### PR TITLE
Add a way to send a MONITOR_STATE via PBT_POWERSETTINGSCHANGE

### DIFF
--- a/src/MainDlg.cpp
+++ b/src/MainDlg.cpp
@@ -1,4 +1,4 @@
-﻿// SendMessage - a tool to send custom messages
+﻿// SendMessage - a tool to send custom messages 
 
 // Copyright (C) 2010, 2012-2015, 2018 - Stefan Kueng
 
@@ -472,8 +472,8 @@ bool CMainDlg::SendPostMessage(UINT id)
         if (lparam == 0)
         {
             LRESULT selIndex = SendDlgItemMessage(*this, IDC_LPARAM, CB_GETCURSEL, 0, 0);
-                if (selIndex != CB_ERR)
-                    lparam = SendDlgItemMessage(*this, IDC_LPARAM, CB_GETITEMDATA, selIndex, 0);
+            if (selIndex != CB_ERR)
+                lparam = SendDlgItemMessage(*this, IDC_LPARAM, CB_GETITEMDATA, selIndex, 0);
         }
 
         struct // copy of POWERBROADCAST_SETTING with a DWORD 4-byte data.

--- a/src/resources/windowmessages.xml
+++ b/src/resources/windowmessages.xml
@@ -249,7 +249,9 @@
     <wparam description="PBT_APMQUERYSUSPEND" value="0x00" />
     <wparam description="PBT_APMQUERYSUSPENDFAILED" value="0x02" />
     <wparam description="PBT_APMRESUMECRITICAL" value="0x06" />
-    <lparam description="not used" value="0" />
+    <lparam description="PowerMonitorOff" value="0x00010000" />
+    <lparam description="PowerMonitorOn"  value="0x00010001" />
+    <lparam description="PowerMonitorDim" value="0x00010010" />
   </Message>
   <Message description="WM_DISPLAYCHANGE" value="0x007E">
     <wparam description="8-bit" value="8" />


### PR DESCRIPTION
I needed a way to mock toggling the monitor state on / off, and I found this nifty little tool to send POWERSETTINGCHANGE. 

I added the struct needed to send the DISPLAY_STATUS and filled it out accordingly while adding the options to the UI. I build the solution in Visual Studio 2017, and tested on a Windows 10 machine that the message was properly received on the other end, but _only_ with a SendMessage. 

As an improvement, we could either gray out the PostMessage UI if the POWERSETTINGCHANGE is set, or we could allocate the memory on the heap and free it when there is a new message or the window changes. Should that be done in this PR, or a different task?